### PR TITLE
Add initial Go SDK

### DIFF
--- a/libs/sdk-go/Makefile
+++ b/libs/sdk-go/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test lint format fmt
+
+fmt:
+	gofmt -w sdk.go sdk_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...
+

--- a/libs/sdk-go/README.md
+++ b/libs/sdk-go/README.md
@@ -1,0 +1,4 @@
+# LangGraph Go SDK
+
+This directory contains a preliminary Go implementation of the LangGraph SDK. It currently exposes a simple `Hello` function as a starting point for migrating functionality to Golang.
+

--- a/libs/sdk-go/go.mod
+++ b/libs/sdk-go/go.mod
@@ -1,0 +1,4 @@
+module github.com/langchain-ai/langgraph-go
+
+go 1.23
+

--- a/libs/sdk-go/sdk.go
+++ b/libs/sdk-go/sdk.go
@@ -1,0 +1,9 @@
+package langgraph
+
+// Hello returns a greeting string.
+func Hello(name string) string {
+	if name == "" {
+		name = "World"
+	}
+	return "Hello, " + name + "!"
+}

--- a/libs/sdk-go/sdk_test.go
+++ b/libs/sdk-go/sdk_test.go
@@ -1,0 +1,11 @@
+package langgraph
+
+import "testing"
+
+func TestHello(t *testing.T) {
+	got := Hello("Go")
+	want := "Hello, Go!"
+	if got != want {
+		t.Errorf("Hello('Go') = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce `sdk-go` as starting point for Golang migration
- add Hello example with tests

## Testing
- `cd libs/sdk-go && make format && make lint && make test`

------
https://chatgpt.com/codex/tasks/task_e_685b8140bf5c832596aeaf2ad19b0bb9