### PR TITLE
Add basic HTTPException to Go SDK

### DIFF
--- a/libs/sdk-go/README.md
+++ b/libs/sdk-go/README.md
@@ -1,4 +1,5 @@
 # LangGraph Go SDK
 
-This directory contains a preliminary Go implementation of the LangGraph SDK. It currently exposes a simple `Hello` function as a starting point for migrating functionality to Golang.
-
+This directory contains a preliminary Go implementation of the LangGraph SDK. It
+initially exposed only a simple `Hello` function. A basic `auth` package has now
+been added with an `HTTPException` type mirroring the Python SDK.

--- a/libs/sdk-go/auth/http_exception.go
+++ b/libs/sdk-go/auth/http_exception.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+    "fmt"
+    "net/http"
+)
+
+// HTTPException represents an HTTP error with a status code, message and optional headers.
+type HTTPException struct {
+    Status  int
+    Detail  string
+    Headers map[string]string
+}
+
+// NewHTTPException creates a new HTTPException. If detail is empty, it uses the
+// standard HTTP status text for the status code. If headers is nil, an empty map
+// is created.
+func NewHTTPException(status int, detail string, headers map[string]string) *HTTPException {
+    if detail == "" {
+        detail = http.StatusText(status)
+        if detail == "" {
+            detail = "Unknown error"
+        }
+    }
+    if headers == nil {
+        headers = map[string]string{}
+    }
+    return &HTTPException{Status: status, Detail: detail, Headers: headers}
+}
+
+// Error implements the error interface.
+func (e *HTTPException) Error() string {
+    return fmt.Sprintf("%d: %s", e.Status, e.Detail)
+}

--- a/libs/sdk-go/auth/http_exception_test.go
+++ b/libs/sdk-go/auth/http_exception_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import "testing"
+
+func TestNewHTTPExceptionDefault(t *testing.T) {
+    err := NewHTTPException(401, "", nil)
+    if err.Status != 401 {
+        t.Errorf("expected status 401, got %d", err.Status)
+    }
+    if err.Detail != "Unauthorized" {
+        t.Errorf("unexpected detail: %s", err.Detail)
+    }
+    if err.Error() != "401: Unauthorized" {
+        t.Errorf("unexpected error string: %s", err.Error())
+    }
+    if err.Headers == nil || len(err.Headers) != 0 {
+        t.Errorf("expected empty headers")
+    }
+}
+
+func TestNewHTTPExceptionCustom(t *testing.T) {
+    headers := map[string]string{"X-Test": "1"}
+    err := NewHTTPException(404, "Not found", headers)
+    if err.Status != 404 || err.Detail != "Not found" {
+        t.Errorf("unexpected err fields: %+v", err)
+    }
+    if err.Headers["X-Test"] != "1" {
+        t.Errorf("unexpected headers: %+v", err.Headers)
+    }
+}


### PR DESCRIPTION
## Summary
- extend `sdk-go` README with current status
- implement `auth` package with `HTTPException`
- add tests for the new type

## Testing
- `cd libs/sdk-go && make test`

------
https://chatgpt.com/codex/tasks/task_e_685b826c697083258c641f19598dc3b9