### PR TITLE
Add Go toolchain setup

### DIFF
--- a/STEP3_TOOLCHAIN.md
+++ b/STEP3_TOOLCHAIN.md
@@ -1,0 +1,26 @@
+# Step 3: Set Up the Go Toolchain
+
+Building on the analysis from [STEP1_ANALYSIS.md](STEP1_ANALYSIS.md) and the repository layout proposed in [STEP2_DESIGN.md](STEP2_DESIGN.md), this step prepares the repository to build Go code.
+
+## Install Go
+
+Install Go 1.23 or higher. The official installer sets the `GOROOT` variable automatically. Create a workspace directory for `GOPATH` if you need to override the default (`~/go`):
+
+```bash
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
+```
+
+## Initialize Go Modules
+
+Each Go package under `libs/` uses its own `go.mod` file. A `go.work` file at the repository root ties these modules together for local development:
+
+```bash
+go work init ./libs/sdk-go
+```
+
+Additional modules will be added to `go.work` as they are created. This allows imports between modules without requiring `replace` directives.
+
+## Next Steps
+
+With the toolchain configured, future steps will implement Go equivalents of the existing libraries and ensure tests run through `make test` in each Go module.

--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.23.8
+
+use ./libs/sdk-go


### PR DESCRIPTION
## Summary
- document step 3 of the migration plan
- introduce a `go.work` to manage Go modules

## Testing
- `make lint` in `libs/sdk-go`
- `make test` in `libs/sdk-go`
- `make format` in `libs/sdk-go`


------
https://chatgpt.com/codex/tasks/task_e_685b8b6802f4832589747b1ddbb1b08c