### PR TITLE
Add skeleton Go modules for step 4 parity

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,9 @@
 go 1.23.8
 
 use ./libs/sdk-go
+use ./libs/checkpoint-go
+use ./libs/checkpoint-postgres-go
+use ./libs/checkpoint-sqlite-go
+use ./libs/cli-go
+use ./libs/langgraph-go
+use ./libs/prebuilt-go

--- a/libs/checkpoint-go/Makefile
+++ b/libs/checkpoint-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w checkpoint.go checkpoint_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/checkpoint-go/README.md
+++ b/libs/checkpoint-go/README.md
@@ -1,0 +1,4 @@
+# checkpoint-go
+
+This package defines basic interfaces for saving LangGraph checkpoints in Go.
+It will serve as the foundation for Postgres and SQLite implementations.

--- a/libs/checkpoint-go/checkpoint.go
+++ b/libs/checkpoint-go/checkpoint.go
@@ -1,0 +1,7 @@
+package checkpoint
+
+// Saver defines the interface for persisting checkpoints.
+type Saver interface {
+	// Save persists the given data and returns a new version identifier.
+	Save(data []byte, version int) (int, error)
+}

--- a/libs/checkpoint-go/checkpoint_test.go
+++ b/libs/checkpoint-go/checkpoint_test.go
@@ -1,0 +1,17 @@
+package checkpoint
+
+import "testing"
+
+type nopSaver struct{}
+
+func (nopSaver) Save(data []byte, version int) (int, error) {
+	return version + 1, nil
+}
+
+func TestSaver(t *testing.T) {
+	var s Saver = nopSaver{}
+	next, err := s.Save([]byte("data"), 1)
+	if err != nil || next != 2 {
+		t.Fatalf("unexpected result: %v %d", err, next)
+	}
+}

--- a/libs/checkpoint-go/go.mod
+++ b/libs/checkpoint-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/langchain-ai/checkpoint-go
+
+go 1.23.8

--- a/libs/checkpoint-postgres-go/Makefile
+++ b/libs/checkpoint-postgres-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w postgres.go postgres_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/checkpoint-postgres-go/README.md
+++ b/libs/checkpoint-postgres-go/README.md
@@ -1,0 +1,4 @@
+# checkpoint-postgres-go
+
+This package will store LangGraph checkpoints in a Postgres database.
+Currently it provides a stub implementation for testing purposes.

--- a/libs/checkpoint-postgres-go/go.mod
+++ b/libs/checkpoint-postgres-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/langchain-ai/checkpoint-postgres-go
+
+go 1.23.8

--- a/libs/checkpoint-postgres-go/postgres.go
+++ b/libs/checkpoint-postgres-go/postgres.go
@@ -1,0 +1,13 @@
+package checkpoint_postgres
+
+import "github.com/langchain-ai/checkpoint-go"
+
+// PostgresSaver is a placeholder checkpoint saver backed by Postgres.
+type PostgresSaver struct{}
+
+func (PostgresSaver) Save(data []byte, version int) (int, error) {
+	// TODO: implement database persistence
+	return version + 1, nil
+}
+
+var _ checkpoint.Saver = PostgresSaver{}

--- a/libs/checkpoint-postgres-go/postgres_test.go
+++ b/libs/checkpoint-postgres-go/postgres_test.go
@@ -1,0 +1,11 @@
+package checkpoint_postgres
+
+import "testing"
+
+func TestPostgresSaver(t *testing.T) {
+	s := PostgresSaver{}
+	next, err := s.Save([]byte("d"), 0)
+	if err != nil || next != 1 {
+		t.Fatalf("unexpected result: %v %d", err, next)
+	}
+}

--- a/libs/checkpoint-sqlite-go/Makefile
+++ b/libs/checkpoint-sqlite-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w sqlite.go sqlite_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/checkpoint-sqlite-go/README.md
+++ b/libs/checkpoint-sqlite-go/README.md
@@ -1,0 +1,4 @@
+# checkpoint-sqlite-go
+
+This package will store LangGraph checkpoints in a SQLite database.
+Currently it provides a stub implementation for testing purposes.

--- a/libs/checkpoint-sqlite-go/go.mod
+++ b/libs/checkpoint-sqlite-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/langchain-ai/checkpoint-sqlite-go
+
+go 1.23.8

--- a/libs/checkpoint-sqlite-go/sqlite.go
+++ b/libs/checkpoint-sqlite-go/sqlite.go
@@ -1,0 +1,13 @@
+package checkpoint_sqlite
+
+import "github.com/langchain-ai/checkpoint-go"
+
+// SQLiteSaver is a placeholder checkpoint saver backed by SQLite.
+type SQLiteSaver struct{}
+
+func (SQLiteSaver) Save(data []byte, version int) (int, error) {
+	// TODO: implement database persistence
+	return version + 1, nil
+}
+
+var _ checkpoint.Saver = SQLiteSaver{}

--- a/libs/checkpoint-sqlite-go/sqlite_test.go
+++ b/libs/checkpoint-sqlite-go/sqlite_test.go
@@ -1,0 +1,11 @@
+package checkpoint_sqlite
+
+import "testing"
+
+func TestSQLiteSaver(t *testing.T) {
+	s := SQLiteSaver{}
+	next, err := s.Save([]byte("d"), 0)
+	if err != nil || next != 1 {
+		t.Fatalf("unexpected result: %v %d", err, next)
+	}
+}

--- a/libs/cli-go/Makefile
+++ b/libs/cli-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w main.go main_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/cli-go/README.md
+++ b/libs/cli-go/README.md
@@ -1,0 +1,3 @@
+# cli-go
+
+A placeholder command-line interface for LangGraph built with Cobra.

--- a/libs/cli-go/go.mod
+++ b/libs/cli-go/go.mod
@@ -1,0 +1,9 @@
+module github.com/langchain-ai/cli-go
+
+go 1.23.8
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/libs/cli-go/go.sum
+++ b/libs/cli-go/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/libs/cli-go/main.go
+++ b/libs/cli-go/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "langgraph",
+		Short: "LangGraph CLI placeholder",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("LangGraph CLI")
+		},
+	}
+	if err := rootCmd.Execute(); err != nil {
+		panic(err)
+	}
+}

--- a/libs/cli-go/main_test.go
+++ b/libs/cli-go/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {
+	// simply ensure the command builds and runs
+	gofunc := func() { main() }
+	gofunc()
+}

--- a/libs/langgraph-go/Makefile
+++ b/libs/langgraph-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w graph.go graph_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/langgraph-go/README.md
+++ b/libs/langgraph-go/README.md
@@ -1,0 +1,3 @@
+# langgraph-go
+
+A stub of the LangGraph core framework implemented in Go.

--- a/libs/langgraph-go/go.mod
+++ b/libs/langgraph-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/langchain-ai/langgraph-go
+
+go 1.23.8

--- a/libs/langgraph-go/graph.go
+++ b/libs/langgraph-go/graph.go
@@ -1,0 +1,10 @@
+package langgraph
+
+// Graph represents a simple directed graph placeholder.
+type Graph struct {
+	Nodes []string
+}
+
+func NewGraph() *Graph {
+	return &Graph{Nodes: []string{}}
+}

--- a/libs/langgraph-go/graph_test.go
+++ b/libs/langgraph-go/graph_test.go
@@ -1,0 +1,10 @@
+package langgraph
+
+import "testing"
+
+func TestNewGraph(t *testing.T) {
+	g := NewGraph()
+	if g == nil || len(g.Nodes) != 0 {
+		t.Fatalf("unexpected graph: %+v", g)
+	}
+}

--- a/libs/prebuilt-go/Makefile
+++ b/libs/prebuilt-go/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt format lint test
+
+fmt:
+	gofmt -w prebuilt.go prebuilt_test.go
+
+format: fmt
+
+lint:
+	go vet ./...
+
+test:
+	go test ./...

--- a/libs/prebuilt-go/README.md
+++ b/libs/prebuilt-go/README.md
@@ -1,0 +1,3 @@
+# prebuilt-go
+
+A stub library containing high-level agent helpers for LangGraph.

--- a/libs/prebuilt-go/go.mod
+++ b/libs/prebuilt-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/langchain-ai/prebuilt-go
+
+go 1.23.8

--- a/libs/prebuilt-go/prebuilt.go
+++ b/libs/prebuilt-go/prebuilt.go
@@ -1,0 +1,6 @@
+package prebuilt
+
+// Placeholder function for a high-level agent pattern.
+func HelloAgent() string {
+	return "hello from prebuilt"
+}

--- a/libs/prebuilt-go/prebuilt_test.go
+++ b/libs/prebuilt-go/prebuilt_test.go
@@ -1,0 +1,9 @@
+package prebuilt
+
+import "testing"
+
+func TestHelloAgent(t *testing.T) {
+	if HelloAgent() != "hello from prebuilt" {
+		t.Fatalf("unexpected output")
+	}
+}

--- a/libs/sdk-go/go.mod
+++ b/libs/sdk-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/langchain-ai/langgraph-go
+module github.com/langchain-ai/sdk-go
 
 go 1.23
 


### PR DESCRIPTION
## Summary
- create initial Go modules for checkpoint, database implementations, CLI, core framework and prebuilt agent helpers
- register all modules in `go.work`
- update Go SDK module path to `github.com/langchain-ai/sdk-go`

## Testing
- `make lint` and `make test` for each new module
- `make lint` and `make test` for existing sdk-go

------
https://chatgpt.com/codex/tasks/task_e_685b8fd96db48325b08d4b629c46e6b1