### PR TITLE
Implement basic DB-backed savers

### DIFF
--- a/libs/checkpoint-postgres-go/go.mod
+++ b/libs/checkpoint-postgres-go/go.mod
@@ -1,3 +1,8 @@
 module github.com/langchain-ai/checkpoint-postgres-go
 
 go 1.23.8
+
+require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
+	github.com/lib/pq v1.10.9 // indirect
+)

--- a/libs/checkpoint-postgres-go/go.sum
+++ b/libs/checkpoint-postgres-go/go.sum
@@ -1,0 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/libs/checkpoint-postgres-go/postgres.go
+++ b/libs/checkpoint-postgres-go/postgres.go
@@ -1,13 +1,42 @@
 package checkpoint_postgres
 
-import "github.com/langchain-ai/checkpoint-go"
+import (
+	"database/sql"
 
-// PostgresSaver is a placeholder checkpoint saver backed by Postgres.
-type PostgresSaver struct{}
+	_ "github.com/lib/pq"
 
-func (PostgresSaver) Save(data []byte, version int) (int, error) {
-	// TODO: implement database persistence
-	return version + 1, nil
+	checkpoint "github.com/langchain-ai/checkpoint-go"
+)
+
+// PostgresSaver persists checkpoints in a Postgres database.
+type PostgresSaver struct {
+	DB *sql.DB
 }
 
-var _ checkpoint.Saver = PostgresSaver{}
+// NewPostgresSaver initializes the saver and ensures required tables exist.
+func NewPostgresSaver(db *sql.DB) (*PostgresSaver, error) {
+	p := &PostgresSaver{DB: db}
+	if err := p.setup(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *PostgresSaver) setup() error {
+	_, err := p.DB.Exec(`CREATE TABLE IF NOT EXISTS checkpoints(
+        version INTEGER PRIMARY KEY,
+        data BYTEA
+    )`)
+	return err
+}
+
+// Save stores the data blob and returns the next version.
+func (p *PostgresSaver) Save(data []byte, version int) (int, error) {
+	next := version + 1
+	if _, err := p.DB.Exec(`INSERT INTO checkpoints(version, data) VALUES($1, $2)`, next, data); err != nil {
+		return version, err
+	}
+	return next, nil
+}
+
+var _ checkpoint.Saver = (*PostgresSaver)(nil)

--- a/libs/checkpoint-postgres-go/postgres_test.go
+++ b/libs/checkpoint-postgres-go/postgres_test.go
@@ -1,11 +1,27 @@
 package checkpoint_postgres
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
 
 func TestPostgresSaver(t *testing.T) {
-	s := PostgresSaver{}
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("mock init: %v", err)
+	}
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS checkpoints").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO checkpoints").WithArgs(1, []byte("d")).WillReturnResult(sqlmock.NewResult(1, 1))
+	s, err := NewPostgresSaver(db)
+	if err != nil {
+		t.Fatalf("new saver: %v", err)
+	}
 	next, err := s.Save([]byte("d"), 0)
 	if err != nil || next != 1 {
 		t.Fatalf("unexpected result: %v %d", err, next)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }

--- a/libs/checkpoint-sqlite-go/go.mod
+++ b/libs/checkpoint-sqlite-go/go.mod
@@ -1,3 +1,5 @@
 module github.com/langchain-ai/checkpoint-sqlite-go
 
 go 1.23.8
+
+require github.com/mattn/go-sqlite3 v1.14.28 // indirect

--- a/libs/checkpoint-sqlite-go/go.sum
+++ b/libs/checkpoint-sqlite-go/go.sum
@@ -1,0 +1,3 @@
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/libs/checkpoint-sqlite-go/sqlite.go
+++ b/libs/checkpoint-sqlite-go/sqlite.go
@@ -1,13 +1,42 @@
 package checkpoint_sqlite
 
-import "github.com/langchain-ai/checkpoint-go"
+import (
+	"database/sql"
 
-// SQLiteSaver is a placeholder checkpoint saver backed by SQLite.
-type SQLiteSaver struct{}
+	_ "github.com/mattn/go-sqlite3"
 
-func (SQLiteSaver) Save(data []byte, version int) (int, error) {
-	// TODO: implement database persistence
-	return version + 1, nil
+	checkpoint "github.com/langchain-ai/checkpoint-go"
+)
+
+// SQLiteSaver persists checkpoints in a SQLite database.
+type SQLiteSaver struct {
+	DB *sql.DB
 }
 
-var _ checkpoint.Saver = SQLiteSaver{}
+// NewSQLiteSaver initializes the saver and ensures required tables exist.
+func NewSQLiteSaver(db *sql.DB) (*SQLiteSaver, error) {
+	s := &SQLiteSaver{DB: db}
+	if err := s.setup(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *SQLiteSaver) setup() error {
+	_, err := s.DB.Exec(`CREATE TABLE IF NOT EXISTS checkpoints(
+        version INTEGER PRIMARY KEY,
+        data BLOB
+    )`)
+	return err
+}
+
+// Save stores the data blob and returns the next version.
+func (s *SQLiteSaver) Save(data []byte, version int) (int, error) {
+	next := version + 1
+	if _, err := s.DB.Exec(`INSERT INTO checkpoints(version, data) VALUES(?, ?)`, next, data); err != nil {
+		return version, err
+	}
+	return next, nil
+}
+
+var _ checkpoint.Saver = (*SQLiteSaver)(nil)

--- a/libs/checkpoint-sqlite-go/sqlite_test.go
+++ b/libs/checkpoint-sqlite-go/sqlite_test.go
@@ -1,9 +1,21 @@
 package checkpoint_sqlite
 
-import "testing"
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
 
 func TestSQLiteSaver(t *testing.T) {
-	s := SQLiteSaver{}
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	s, err := NewSQLiteSaver(db)
+	if err != nil {
+		t.Fatalf("new saver: %v", err)
+	}
 	next, err := s.Save([]byte("d"), 0)
 	if err != nil || next != 1 {
 		t.Fatalf("unexpected result: %v %d", err, next)


### PR DESCRIPTION
## Summary
- add SQLite-backed saver implementation
- add Postgres-backed saver implementation
- update unit tests to exercise database logic
- include new module dependencies

## Testing
- `make format lint test` in `libs/checkpoint-sqlite-go`
- `make format lint test` in `libs/checkpoint-postgres-go`


------
https://chatgpt.com/codex/tasks/task_e_685b927deb608325863cc474d7556a69