### PR TITLE
Clarify docs install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,8 @@ see a preview of the documentation on the pull request page.
 
 From the **monorepo root**, run the following command to install the dependencies:
 
-<!-- TODO -->
+Run the following command to install the Python dependencies required for
+building the documentation:
 ```bash
 poetry install --with docs --no-root
 ```


### PR DESCRIPTION
## Summary
- update CONTRIBUTING docs with instructions for installing documentation dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b9577aa28832581f598629480b324